### PR TITLE
fix bug when deleted fork

### DIFF
--- a/grinexplorer/explorer/views.py
+++ b/grinexplorer/explorer/views.py
@@ -168,7 +168,7 @@ class BlockList(ListView):
             context["total_emission"] = Block.objects.order_by("total_difficulty").last().height * 60
 
             context["competing_chains"] = Block.objects \
-                                               .filter(height__gte=context["highest_block"].height - 100) \
+                                               .filter(height__gte=context["highest_block"].height - 60) \
                                                .values("height") \
                                                .annotate(cnt=Count("height")) \
                                                .aggregate(Max("cnt"))["cnt__max"]


### PR DESCRIPTION
the min height to detect fork should be consistent, which is current height - 60.

otherwise, the buggy screenshot is: 
<img width="694" alt="2019-01-23 15 21 47" src="https://user-images.githubusercontent.com/150021/51589664-9fb06f00-1f22-11e9-852f-0fc89642e846.png">

