### PR TITLE
Update README: fix spam link to the official domain

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,6 +1,6 @@
 * Grin-Explorer
 
-Grin-Explorer is the first block explorer for the [[https://grin-tech.org][Grin]]
+Grin-Explorer is the first block explorer for the [[https://grin.mw][Grin]]
 blockchain. This is the source code for the instance running at 
 [[https://grinexplorer.net]].
 


### PR DESCRIPTION
The current link leads to the old domain that is expired and currently used as a spam website.

I changed the link to GRIN official website: https://grin.mw