### PR TITLE
Update to psycopg 2.8.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Django==2.2.13
-psycopg2==2.7.3.2
+psycopg2==2.8.6
 requests==2.20.0
 django_chartit==0.2.9


### PR DESCRIPTION
Won't build with python 3.8 otherwise.