### PR TITLE
Add viewport meta tag

### DIFF
--- a/grinexplorer/templates/base.html
+++ b/grinexplorer/templates/base.html
@@ -16,6 +16,7 @@
 	<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.2/css/all.css"
 		integrity="sha384-oS3vJWv+0UjzBfQzYUhtDYW+Pj2yciDJxpsK1OYPAYjqT085Qq/1cq5FLXAZQ7Ay" crossorigin="anonymous">
 	{% block chart_loader_header %}{% endblock %}
+	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 </head>
 
 <body>


### PR DESCRIPTION
Add viewport meta tag to fix responsive layout on mobile devices

Before| After
-- | --
![image](https://user-images.githubusercontent.com/8020386/209620926-18faa95d-84ba-4157-95ec-b93e7b653403.png)  | ![image](https://user-images.githubusercontent.com/8020386/209621007-6fe3d166-d50c-474b-b953-96c854bd484f.png) | 
![image](https://user-images.githubusercontent.com/8020386/209621149-fa05456d-7fce-48dc-83d7-f4bff61bc6aa.png) | ![image](https://user-images.githubusercontent.com/8020386/209621210-327e386d-23da-4535-b4c9-763e4611281c.png)
